### PR TITLE
Parse message bodies with complex types

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func init() {
 Poll SQS queues specified in a config and enqueue Sidekiq jobs with the queue items.
 It gracefully stops when sent SIGTERM.`
 
-	app.Version = "1.3"
+	app.Version = "1.4"
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
We assumed initially that every field in an SNS message would be a
string. However some of them can be complex objects. We can avoid
having to figure that out by just parsing them all to json.RawMessage
and then parsing the only two fields we actually need to strings.