### PR TITLE
Fix golint installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
   - master
 
 before_script:
-  - go get -u github.com/golang/lint/...
+  - go get -u golang.org/x/lint/golint
 
 script:
   - test -z $(gofmt -l .)


### PR DESCRIPTION
We need to stop importing golint from the github mirror since that is
now disallowed.

See https://github.com/golang/lint/commit/5906bd5c48cd840279ace88b165057fbbd7fb35a