### PR TITLE
add liveness check

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"strconv"
+)
+
+type context struct {
+	DaemonName  string
+	PidFileName string
+	WorkDir     string
+}
+
+func setContext() {
+	workDir, _ := os.Getwd()
+
+	daemonContext = &context{
+		DaemonName:  app.Name,
+		PidFileName: app.Name + ".pid",
+		WorkDir:     workDir,
+	}
+}
+
+func (c *context) writePIDFile() (err error) {
+	filePath := c.WorkDir + "/" + c.PidFileName
+
+	if _, err := os.Stat(filePath); err == nil {
+		return errors.New("PID file exists, scout daemon already running")
+	} else if os.IsNotExist(err) {
+		pid := strconv.Itoa(os.Getpid())
+		return ioutil.WriteFile(filePath, []byte(pid), 0644)
+	}
+
+	return nil
+}
+
+func (c *context) findPIDFile() (err error) {
+	filePath := c.WorkDir + "/" + c.PidFileName
+	if _, err := os.Stat(filePath); err == nil {
+		return nil
+	}
+
+	return errors.New("No PID File found")
+}
+
+func (c *context) removePIDFile() (err error) {
+	filePath := c.WorkDir + "/" + c.PidFileName
+	if _, err = os.Stat(filePath); err == nil {
+		return os.Remove(c.PidFileName)
+	}
+	return err
+}

--- a/main_test.go
+++ b/main_test.go
@@ -77,8 +77,11 @@ func (w *WaitQueue) Poll() {
 // waitListen just calls listen and then sends `3 on the sequence channel when
 // the call exits
 func waitListen(q Queue, freq <-chan time.Time, seq chan int) {
+	setContext()
+	daemonContext.writePIDFile()
 	Listen(q, freq)
 	seq <- 3
+	daemonContext.removePIDFile()
 }
 
 // This test is pretty complicated because I'm basically using it to ensure that
@@ -99,6 +102,9 @@ func TestSignals(t *testing.T) {
 		seq:  seq,
 		wait: wait,
 	}
+
+	setContext()
+	daemonContext.writePIDFile()
 
 	// begin listening
 	go waitListen(queue, freq, seq)
@@ -123,4 +129,6 @@ func TestSignals(t *testing.T) {
 	// then Listen() should exit
 	val = <-seq
 	require.Equal(t, val, 3)
+
+	daemonContext.removePIDFile()
 }

--- a/queue.go
+++ b/queue.go
@@ -62,6 +62,8 @@ func (q *queue) Semaphore() *sync.WaitGroup {
 func (q *queue) Poll() {
 	if q.Sem != nil {
 		defer q.Sem.Done()
+	} else {
+		log.Info("Polling inside Poll function")
 	}
 
 	messages, err := q.SQSClient.Fetch()

--- a/router.go
+++ b/router.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+func newRouter() *mux.Router {
+	var router = mux.NewRouter()
+	router.HandleFunc("/status", statusHandler).Methods("GET")
+	return router
+}
+
+func statusHandler(w http.ResponseWriter, r *http.Request) {
+	response := map[string]string{
+		"app":     app.Name,
+		"version": app.Version,
+		"status":  "OK",
+	}
+
+	if err := daemonContext.findPIDFile(); err == nil {
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type RouterTestSuite struct {
+	suite.Suite
+	assert *require.Assertions
+	router *mux.Router
+}
+
+func TestRouter(t *testing.T) {
+	suite.Run(t, new(RouterTestSuite))
+}
+
+func (suite *RouterTestSuite) SetupTest() {
+	setContext()
+	daemonContext.writePIDFile()
+	suite.router = newRouter()
+}
+
+func (suite *RouterTestSuite) TearDownTest() {
+	daemonContext.removePIDFile()
+}
+
+func (suite *RouterTestSuite) TestRouter_Success() {
+	req, err := http.NewRequest("GET", "/status", nil)
+	suite.Nil(err)
+	resp := httptest.NewRecorder()
+	suite.router.ServeHTTP(resp, req)
+	suite.Equal(http.StatusOK, resp.Code)
+}


### PR DESCRIPTION
Adds liveness check to support container deployments. Exposes `/status` and returns 
```
{
  app: "scout",
  status: "OK",
  version: "1.5"
}
```